### PR TITLE
Update maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Identifier:** <https://stac-extensions.github.io/sentinel-2/v1.0.0/schema.json>
 - **Field Name Prefix:** s2
 - **Scope:** Item
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Stable
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Candidate
 - **Owner**: @philvarner
 
 This document explains the Sentinel-2 Extension to the [SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC) specification.


### PR DESCRIPTION
It feels weird that this extension jumped directly to stable, especially considering:
1. the open issues
2. the intro that suggest breaking changes
3. the number of (public) implementations seems < 6
4. ESA did never approve this (and doesn't seem happy with it either)

I'd propose to change to Candidate.

Fixed #8.