### PR TITLE
Deprecated s2:product_type in favor of `product:type` #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `s2:product_type` in favor of `product:type`
+- `s2:snow_ice_percentage` in favor of `eo:snow_cover`
 - `s2:generation_time` in favor of `processing:datetime`
-
 - `s2:processing_baseline` in favor of `processing:version`
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The fields in the table below can be used in these parts of STAC documents:
 | s2:datatake_id                          | string   | Datatake Identifier                                          |
 | s2:product_uri                          | string   | Product URI                                                  |
 | s2:datastrip_id                         | string   | Datastrip Identifier                                         |
-| s2:product_type                         | string   | Product Type                                                 |
 | s2:datatake_type                        | string   | Datatake Type                                                |
 | s2:reflectance_conversion_factor        | number   | Reflectance Conversion Factor                                |
 | s2:water_percentage                     | number   | Water Percentage                                             |
@@ -52,6 +51,7 @@ The fields in the table below can be used in these parts of STAC documents:
 | s2:high_proba_clouds_percentage         | number   | High Probability Clouds Percentage                           |
 | s2:medium_proba_clouds_percentage       | number   | Medium Probability Clouds Percentage                         |
 | s2:saturated_defective_pixel_percentage | number   | Saturated Defective Pixel Percentage                         |
+| s2:product_type                         | string   | **DEPRECATED** in favor of `product:type`. Product Type      |
 | s2:snow_ice_percentage                  | number   | **DEPRECATED** in favor of `eo:snow_cover`. Snow and Ice Percentage |
 | s2:generation_time                      | datetime | **DEPRECATED** in favor of `processing:datetime`. Generation Time |
 | s2:processing_baseline                  | string   | **DEPRECATED** in favor of `processing:version`. [Processing Baseline](https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-2-msi/processing-baseline) |

--- a/examples/item.json
+++ b/examples/item.json
@@ -709,7 +709,7 @@
     "s2:datatake_id": "GS2A_20231107T144731_043751_N05.09",
     "s2:product_uri": "S2A_MSIL2A_20231107T144731_N0509_R139_T20QRF_20231107T182159.SAFE",
     "s2:datastrip_id": "S2A_OPER_MSI_L2A_DS_MSFT_20231107T182159_S20231107T144729_N05.09",
-    "s2:product_type": "S2MSI2A",
+    "product:type": "S2MSI2A",
     "sat:orbit_state": "descending",
     "s2:datatake_type": "INS-NOBS",
     "processing:datetime": "2023-11-07T18:21:59.14490Z",
@@ -735,7 +735,8 @@
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+    "https://stac-extensions.github.io/processing/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/product/v0.1.0/schema.json"
   ],
   "stac_version": "1.0.0"
 }

--- a/examples/item2.json
+++ b/examples/item2.json
@@ -38,7 +38,7 @@
     "view:sun_azimuth": 62.3286549448294,
     "view:sun_elevation": 57.292926148638,
     "s2:product_uri": "S2A_MSIL2A_20190212T192651_N0212_R013_T07HFE_20201007T160857.SAFE",
-    "s2:product_type": "S2MSI2A",
+    "product:type": "S2MSI2A",
     "s2:datatake_id": "GS2A_20190212T192651_019029_N02.12",
     "s2:datatake_type": "INS-NOBS",
     "s2:datastrip_id": "S2A_OPER_MSI_L2A_DS_ESRI_20201007T160858_S20190212T192646_N02.12",
@@ -1789,7 +1789,8 @@
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json",
     "https://stac-extensions.github.io/grid/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/product/v0.1.0/schema.json"
   ],
   "collection": "sentinel2-l2a-example"
 }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -56,7 +56,6 @@
         { "required": ["s2:datatake_id"] },
         { "required": ["s2:product_uri"] },
         { "required": ["s2:datastrip_id"] },
-        { "required": ["s2:product_type"] },
         { "required": ["s2:datatake_type"] },
         { "required": ["s2:water_percentage"] },
         { "required": ["s2:vegetation_percentage"] },
@@ -99,7 +98,8 @@
         },
         "s2:product_type": {
           "title": "Product Type",
-          "type": "string"
+          "type": "string",
+          "deprecated": true
         },
         "s2:datatake_type": {
           "title": "Datatake Type",


### PR DESCRIPTION
Deprecated s2:product_type in favor of `product:type` #2

Similar to #13 and #14